### PR TITLE
dialyzer support

### DIFF
--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -1,0 +1,5 @@
+###
+### This is not a comment, just a pattern that is
+### very unlikely to match anything that we care about.
+### Don't put blank lines in this file.
+###


### PR DESCRIPTION
Try to dialyzer for search of errors. 

make build_plt

Wait about 60 minutes

make dialyzer

It has shown to me about 255 warnings https://gist.github.com/1559052

For example:

src/apps/apps_streaming.erl:77: Call to missing or unexported function rtmp_session:close_stream/2
src/auth_iphone.erl:11: Call to missing or unexported function json_session:binary_to_hexbin/1
src/ems_event.erl:162: Call to missing or unexported function gen_event:remove_handler/2
src/ems_rtmp.erl:82: Call to missing or unexported function rtmp_session:call_function/3
src/erlyvideo.erl:207: Call to missing or unexported function rtmp_session:collect_stats/1
src/glue_mp4.erl:39: Call to missing or unexported function mp4_reader:open/2
src/glue_mp4.erl:40: Call to missing or unexported function mp4_reader:first/1
src/http/ems_http_mp4_export.erl:52: Call to missing or unexported function mp4_writer:dump_media/2
src/rtmp_lib.erl:159: Call to missing or unexported function erlang:raise/1
src/sdp.erl:275: Call to missing or unexported function sdp_encoder:encode/2
